### PR TITLE
Adding jmh perf test to compare Agrona vs JGroup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,11 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-build-helper-plugin.version>3.2.0</maven-build-helper-plugin.version>
+        <jmh.version>1.33</jmh.version>
+        <agrona.version>1.12.0</agrona.version>
     </properties>
 
     <developers>
@@ -45,6 +50,18 @@
             <version>2.14.1</version>
         </dependency>
         <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.agrona</groupId>
+            <artifactId>agrona</artifactId>
+            <version>${agrona.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <!--suppress MavenPackageUpdate -->
@@ -53,5 +70,79 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${maven-build-helper-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/test/jmh</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.openjdk.jmh</groupId>
+                                    <artifactId>jmh-generator-annprocess</artifactId>
+                                    <version>${jmh.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven-assembly-plugin.version}</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/jmh-tests.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <attach>true</attach>
+                            <archive>
+                                <manifest>
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/main/assembly/jmh-tests.xml
+++ b/src/main/assembly/jmh-tests.xml
@@ -1,0 +1,26 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+   <id>jmh-tests</id>
+   <formats>
+      <format>jar</format>
+   </formats>
+   <includeBaseDirectory>false</includeBaseDirectory>
+   <dependencySets>
+      <dependencySet>
+         <outputDirectory>/</outputDirectory>
+         <useProjectArtifact>true</useProjectArtifact>
+         <unpack>true</unpack>
+         <scope>test</scope>
+      </dependencySet>
+   </dependencySets>
+   <fileSets>
+      <fileSet>
+         <directory>${project.build.directory}/test-classes</directory>
+         <outputDirectory>/</outputDirectory>
+         <includes>
+            <include>**/*</include>
+         </includes>
+         <useDefaultExcludes>true</useDefaultExcludes>
+      </fileSet>
+   </fileSets>
+</assembly>

--- a/src/test/jmh/org/jgroups/shm/CopyBytesBenchmarks.java
+++ b/src/test/jmh/org/jgroups/shm/CopyBytesBenchmarks.java
@@ -1,0 +1,64 @@
+package org.jgroups.shm;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import static org.jgroups.shm.ByteBufferUtils.copyBytes;
+
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgsAppend = "-Dagrona.disable.bounds.checks=true")
+public class CopyBytesBenchmarks {
+
+   @Param({"8", "64", "1024"})
+   int bytes;
+   @Param({"true", "false"})
+   boolean direct;
+   private byte[] src;
+   private UnsafeBuffer agronaBuffer;
+   private ByteBuffer nioBuffer;
+   private int srcIndex;
+   private int dstIndex;
+
+   @Setup
+   public void setup() {
+      src = new byte[bytes];
+      nioBuffer = direct ? ByteBuffer.allocateDirect(bytes) : ByteBuffer.allocate(bytes);
+      agronaBuffer = new UnsafeBuffer(nioBuffer);
+      srcIndex = 0;
+      dstIndex = 0;
+   }
+
+   @Benchmark
+   @BenchmarkMode({Mode.AverageTime})
+   @Warmup(time = 1)
+   @Measurement(time = 1)
+   @OutputTimeUnit(TimeUnit.NANOSECONDS)
+   public byte jgroupsCopyBytes() {
+      copyBytes(src, srcIndex, nioBuffer, dstIndex, bytes);
+      return nioBuffer.get(dstIndex);
+   }
+
+   @Benchmark
+   @BenchmarkMode({Mode.AverageTime})
+   @Warmup(time = 1)
+   @Measurement(time = 1)
+   @OutputTimeUnit(TimeUnit.NANOSECONDS)
+   public int agronaCopyBytes() {
+      agronaBuffer.putBytes(dstIndex, src, srcIndex, bytes);
+      return nioBuffer.get(dstIndex);
+   }
+
+}

--- a/src/test/jmh/org/jgroups/shm/ManyToOneBurstBenchmark.java
+++ b/src/test/jmh/org/jgroups/shm/ManyToOneBurstBenchmark.java
@@ -1,0 +1,225 @@
+package org.jgroups.shm;
+
+import org.agrona.BitUtil;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
+import org.agrona.concurrent.ringbuffer.RecordDescriptor;
+import org.agrona.concurrent.ringbuffer.RingBufferDescriptor;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.Consumer;
+
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgsAppend = "-Dagrona.disable.bounds.checks=true")
+public class ManyToOneBurstBenchmark {
+
+   private static final int MESSAGE_COUNT_LIMIT = 16;
+
+   @Param({"1", "100"})
+   private int burstLength;
+
+   @Param({"agrona", "jgroups"})
+   private String ringBufferType;
+
+   private final AtomicBoolean running = new AtomicBoolean(true);
+   private final AtomicInteger producerId = new AtomicInteger();
+   private ProducerState[] producerStates;
+
+   private Thread consumerThread;
+
+   private Consumer<int[]> sendBurstOperation;
+
+   @Setup
+   public synchronized void setup(BenchmarkParams params) {
+      producerStates = new ProducerState[params.getThreads()];
+
+      Runnable consumerTask;
+
+      switch (ringBufferType) {
+         case "agrona":
+            final ManyToOneRingBuffer agronaRingBuffer = createAgronaRingBuffer(Integer.BYTES, burstLength, params.getThreads());
+            consumerTask = createAgronaConsumer(agronaRingBuffer, producerStates, running, MESSAGE_COUNT_LIMIT);
+            sendBurstOperation = burst -> {
+               sendAgronaBurst(agronaRingBuffer, burst);
+            };
+            break;
+         case "jgroups":
+            final ManyToOneBoundedChannel jgroupsChannel = createJGroupsChannel(Integer.BYTES, burstLength, params.getThreads());
+            consumerTask = createJGroupsConsumer(jgroupsChannel, producerStates, running, MESSAGE_COUNT_LIMIT);
+            sendBurstOperation = burst -> {
+               sendJGroupsBurst(jgroupsChannel, burst);
+            };
+            break;
+         default:
+            throw new UnsupportedOperationException("unsupported ring buffer type");
+      }
+
+      consumerThread = new Thread(consumerTask);
+
+      consumerThread.setName("consumer");
+      consumerThread.start();
+   }
+
+   private static Runnable createAgronaConsumer(ManyToOneRingBuffer ringBuffer,
+                                                ProducerState[] states,
+                                                AtomicBoolean running,
+                                                int messageCountLimit) {
+      return () -> {
+         while (true) {
+            final int msgCount = ringBuffer.read((msgTypeId, buffer, index, length) -> {
+               final int value = buffer.getInt(index);
+               if (value >= 0) {
+                  states[value].completed();
+               }
+            }, messageCountLimit);
+            if (0 == msgCount && !running.get()) {
+               break;
+            }
+         }
+      };
+   }
+
+   private static Runnable createJGroupsConsumer(ManyToOneBoundedChannel ringBuffer,
+                                                 ProducerState[] states,
+                                                 AtomicBoolean running,
+                                                 int messageCountLimit) {
+      return () -> {
+         while (true) {
+            final int msgCount = ringBuffer.read((msgTypeId, buffer, index, length) -> {
+               final int value = buffer.getInt(index);
+               if (value >= 0) {
+                  states[value].completed();
+               }
+            }, messageCountLimit);
+            if (0 == msgCount && !running.get()) {
+               break;
+            }
+         }
+      };
+   }
+
+   @TearDown
+   public synchronized void tearDown() throws Exception {
+      running.set(false);
+      consumerThread.join();
+   }
+
+   private static ManyToOneRingBuffer createAgronaRingBuffer(int expectedEntrySize, int burstSize, int producers) {
+      final int entries = Math.max(8, burstSize);
+      final int entryCapacity = BitUtil.align(expectedEntrySize + RecordDescriptor.HEADER_LENGTH, RecordDescriptor.ALIGNMENT);
+      final int dataCapacity = BitUtil.findNextPositivePowerOfTwo(entryCapacity * entries * producers);
+      final int bufferCapacity = dataCapacity + RingBufferDescriptor.TRAILER_LENGTH;
+      return new ManyToOneRingBuffer(new UnsafeBuffer(ByteBuffer.allocateDirect(bufferCapacity)));
+   }
+
+   private static ManyToOneBoundedChannel createJGroupsChannel(int expectedEntrySize, int burstSize, int producers) {
+      final int entries = Math.max(8, burstSize);
+      final int entryCapacity = BitUtil.align(expectedEntrySize + ManyToOneBoundedChannel.RecordDescriptor.HEADER_LENGTH, ManyToOneBoundedChannel.RecordDescriptor.ALIGNMENT);
+      final int dataCapacity = BitUtil.findNextPositivePowerOfTwo(entryCapacity * entries * producers);
+      final int bufferCapacity = dataCapacity + ManyToOneBoundedChannel.TRAILER_LENGTH;
+      return new ManyToOneBoundedChannel(ByteBuffer.allocateDirect(bufferCapacity).order(ByteOrder.nativeOrder()));
+   }
+
+   @State(Scope.Thread)
+   public static class ProducerState {
+
+      private static final int TRUE = 1;
+      private static final int FALSE = 0;
+      private static final AtomicIntegerFieldUpdater<ProducerState> COMPLETED_UPDATER = AtomicIntegerFieldUpdater.newUpdater(ProducerState.class, "completed");
+      /**
+       * Using updater + int to allow JMH to pad it to avoid false sharing with other producers states
+       */
+      private volatile int completed;
+      private int id;
+      private int[] burst;
+
+      @Setup
+      public void setup(final ManyToOneBurstBenchmark sharedState) {
+         id = sharedState.producerId.getAndIncrement();
+         burst = new int[sharedState.burstLength];
+         Arrays.fill(burst, Integer.MIN_VALUE);
+         // last value must be the producer index/id to allow consumer to "complete" burst
+         burst[burst.length - 1] = id;
+         completed = FALSE;
+         sharedState.producerStates[id] = this;
+      }
+
+      public void completed() {
+         COMPLETED_UPDATER.lazySet(this, TRUE);
+      }
+
+      private int waitCompletionAndReset() {
+         int value;
+         while ((value = completed) != TRUE) {
+            Thread.onSpinWait();
+         }
+         COMPLETED_UPDATER.lazySet(this, FALSE);
+         return value;
+      }
+   }
+
+   private static void sendAgronaBurst(ManyToOneRingBuffer ringBuffer, final int[] burst) {
+      for (int value : burst) {
+         int index;
+         while ((index = ringBuffer.tryClaim(1, Integer.BYTES)) <= 0) {
+            Thread.onSpinWait();
+         }
+         ringBuffer.buffer().putInt(index, value);
+         ringBuffer.commit(index);
+      }
+   }
+
+   private static void sendJGroupsBurst(ManyToOneBoundedChannel ringBuffer, final int[] burst) {
+      for (int value : burst) {
+         long claim;
+         while ((claim = ringBuffer.tryClaim(1, Integer.BYTES)) == ManyToOneBoundedChannel.INSUFFICIENT_CAPACITY) {
+            Thread.onSpinWait();
+         }
+         ringBuffer.buffer().putInt(ManyToOneBoundedChannel.claimedIndex(claim), value);
+         ringBuffer.commit(claim);
+      }
+   }
+
+   public int sendAndAwaitBurstCompletion(ProducerState producer) {
+      this.sendBurstOperation.accept(producer.burst);
+      return producer.waitCompletionAndReset();
+   }
+
+   @Benchmark
+   @BenchmarkMode({Mode.AverageTime})
+   @Warmup(time = 1)
+   @Measurement(time = 1)
+   @OutputTimeUnit(TimeUnit.MICROSECONDS)
+   @Threads(1)
+   public int test1Producer(final ProducerState state) {
+      return sendAndAwaitBurstCompletion(state);
+   }
+
+   @Benchmark
+   @BenchmarkMode({Mode.AverageTime})
+   @Warmup(time = 1)
+   @Measurement(time = 1)
+   @OutputTimeUnit(TimeUnit.MICROSECONDS)
+   @Threads(2)
+   public int test2Producers(final ProducerState state) {
+      return sendAndAwaitBurstCompletion(state);
+   }
+
+   @Benchmark
+   @BenchmarkMode({Mode.AverageTime})
+   @Warmup(time = 1)
+   @Measurement(time = 1)
+   @OutputTimeUnit(TimeUnit.MICROSECONDS)
+   @Threads(3)
+   public int test3Producers(final ProducerState state) {
+      return sendAndAwaitBurstCompletion(state);
+   }
+}


### PR DESCRIPTION
These are the results on my machine (with JDK 11):

```
JDK 11:
Benchmark                               (burstLength)  (ringBufferType)  Mode  Cnt   Score   Error  Units
ManyToOneBurstBenchmark.test1Producer               1            agrona  avgt   10   0.143 ± 0.012  us/op
ManyToOneBurstBenchmark.test1Producer               1           jgroups  avgt   10   0.144 ± 0.006  us/op
ManyToOneBurstBenchmark.test1Producer             100            agrona  avgt   10   3.018 ± 0.168  us/op
ManyToOneBurstBenchmark.test1Producer             100           jgroups  avgt   10   3.183 ± 0.104  us/op
ManyToOneBurstBenchmark.test2Producers              1            agrona  avgt   10   0.193 ± 0.010  us/op
ManyToOneBurstBenchmark.test2Producers              1           jgroups  avgt   10   0.179 ± 0.008  us/op
ManyToOneBurstBenchmark.test2Producers            100            agrona  avgt   10   9.553 ± 0.999  us/op
ManyToOneBurstBenchmark.test2Producers            100           jgroups  avgt   10  11.179 ± 0.172  us/op

Benchmark                             (bytes)  (direct)  Mode  Cnt   Score   Error  Units
CopyBytesBenchmarks.agronaCopyBytes         8      true  avgt   10   7.848 ± 0.246  ns/op
CopyBytesBenchmarks.agronaCopyBytes         8     false  avgt   10   8.905 ± 0.170  ns/op
CopyBytesBenchmarks.agronaCopyBytes        64      true  avgt   10   7.750 ± 0.224  ns/op
CopyBytesBenchmarks.agronaCopyBytes        64     false  avgt   10   9.402 ± 0.629  ns/op
CopyBytesBenchmarks.agronaCopyBytes      1024      true  avgt   10  24.534 ± 0.877  ns/op
CopyBytesBenchmarks.agronaCopyBytes      1024     false  avgt   10  22.332 ± 0.700  ns/op
CopyBytesBenchmarks.jgroupsCopyBytes        8      true  avgt   10   7.663 ± 0.220  ns/op
CopyBytesBenchmarks.jgroupsCopyBytes        8     false  avgt   10   8.490 ± 0.400  ns/op
CopyBytesBenchmarks.jgroupsCopyBytes       64      true  avgt   10   7.961 ± 0.384  ns/op
CopyBytesBenchmarks.jgroupsCopyBytes       64     false  avgt   10   8.676 ± 0.376  ns/op
CopyBytesBenchmarks.jgroupsCopyBytes     1024      true  avgt   10  24.444 ± 0.555  ns/op
CopyBytesBenchmarks.jgroupsCopyBytes     1024     false  avgt   10  22.377 ± 0.918  ns/op
```

It didn't show any evident difference with Agrona (if not the ring buffer under contention)
I can investigate what's going on there, but I was expecting some big difference
