### PR TITLE
Adding throughput jmh benchmarks

### DIFF
--- a/src/test/jmh/org/jgroups/shm/AgronaRingBufferFactory.java
+++ b/src/test/jmh/org/jgroups/shm/AgronaRingBufferFactory.java
@@ -1,0 +1,21 @@
+package org.jgroups.shm;
+
+import java.nio.ByteBuffer;
+
+import org.agrona.BitUtil;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
+import org.agrona.concurrent.ringbuffer.RecordDescriptor;
+import org.agrona.concurrent.ringbuffer.RingBufferDescriptor;
+
+final class AgronaRingBufferFactory {
+
+   public static ManyToOneRingBuffer createManyToOneRingBuffer(int expectedEntrySize, int capacity) {
+      final int entries = Math.max(8, capacity);
+      final int entryCapacity = BitUtil.align(expectedEntrySize + RecordDescriptor.HEADER_LENGTH, RecordDescriptor.ALIGNMENT);
+      final int dataCapacity = BitUtil.findNextPositivePowerOfTwo(entryCapacity * entries);
+      final int bufferCapacity = dataCapacity + RingBufferDescriptor.TRAILER_LENGTH;
+      return new ManyToOneRingBuffer(new UnsafeBuffer(ByteBuffer.allocateDirect(bufferCapacity)));
+   }
+
+}

--- a/src/test/jmh/org/jgroups/shm/JGroupsChannelFactory.java
+++ b/src/test/jmh/org/jgroups/shm/JGroupsChannelFactory.java
@@ -1,0 +1,17 @@
+package org.jgroups.shm;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.agrona.BitUtil;
+
+final class JGroupsChannelFactory {
+
+   public static ManyToOneBoundedChannel createManyToOneBoundedChannel(int expectedEntrySize, int capacity) {
+      final int entries = Math.max(8, capacity);
+      final int entryCapacity = BitUtil.align(expectedEntrySize + ManyToOneBoundedChannel.RecordDescriptor.HEADER_LENGTH, ManyToOneBoundedChannel.RecordDescriptor.ALIGNMENT);
+      final int dataCapacity = BitUtil.findNextPositivePowerOfTwo(entryCapacity * entries);
+      final int bufferCapacity = dataCapacity + ManyToOneBoundedChannel.TRAILER_LENGTH;
+      return new ManyToOneBoundedChannel(ByteBuffer.allocateDirect(bufferCapacity).order(ByteOrder.nativeOrder()));
+   }
+}

--- a/src/test/jmh/org/jgroups/shm/ManyToOneStreamBenchmark.java
+++ b/src/test/jmh/org/jgroups/shm/ManyToOneStreamBenchmark.java
@@ -1,0 +1,180 @@
+package org.jgroups.shm;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.ToIntFunction;
+
+import org.agrona.concurrent.MessageHandler;
+import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Group)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(value = 2, jvmArgsAppend = "-Dagrona.disable.bounds.checks=true")
+public class ManyToOneStreamBenchmark {
+
+   private static final long DELAY_PRODUCER = Long.getLong("delay.p", 0L);
+   private static final long DELAY_CONSUMER = Long.getLong("delay.c", 0L);
+
+   @Param({"agrona", "jgroups"})
+   private String ringBufferType;
+
+   @Param({"100", "1000"})
+   private int bytes;
+
+   @Param(value = {"132000"})
+   int capacity;
+
+   private int sentinelValue = -1;
+
+   private ToIntFunction<OfferCounters> sendOperation;
+   private ToIntFunction<PollCounters> receiveOperation;
+   private BooleanSupplier isEmpty;
+
+   @Setup
+   public void setup() {
+      if (bytes < 4) {
+         throw new IllegalArgumentException("cannot configure less then 4 bytes per ring buffer entry");
+      }
+
+      final int bytes = this.bytes;
+
+      switch (ringBufferType) {
+         case "agrona":
+            final ManyToOneRingBuffer agronaRingBuffer = AgronaRingBufferFactory.createManyToOneRingBuffer(bytes, capacity);
+            sendOperation = counters -> {
+               int index;
+               while ((index = agronaRingBuffer.tryClaim(1, bytes)) < 0) {
+                  counters.offersFailed++;
+                  backoff();
+               }
+               agronaRingBuffer.buffer().putInt(index, sentinelValue);
+               agronaRingBuffer.commit(index);
+               counters.offersMade++;
+               return index;
+            };
+            MessageHandler agronaHandler = (msgTypeId, buffer, index, length) -> {
+               if (buffer.getInt(index) != sentinelValue) {
+                  throw new RuntimeException("CANNOT HAPPEN!");
+               }
+               if (DELAY_CONSUMER != 0) {
+                  Blackhole.consumeCPU(DELAY_CONSUMER);
+               }
+            };
+            receiveOperation = counters -> {
+               final int done = agronaRingBuffer.read(agronaHandler);
+               if (done == 0) {
+                  counters.pollsFailed++;
+                  backoff();
+               } else {
+                  counters.pollsMade += done;
+               }
+               return done;
+            };
+            isEmpty = () -> agronaRingBuffer.size() == 0;
+            break;
+         case "jgroups":
+            final ManyToOneBoundedChannel jgroupsChannel = JGroupsChannelFactory.createManyToOneBoundedChannel(bytes, capacity);
+            sendOperation = counters -> {
+               long claim;
+               while ((claim = jgroupsChannel.tryClaim(1, bytes)) < 0) {
+                  counters.offersFailed++;
+                  backoff();
+               }
+               final int index = ManyToOneBoundedChannel.claimedIndex(claim);
+               jgroupsChannel.buffer().putInt(index, sentinelValue);
+               jgroupsChannel.commit(claim);
+               counters.offersMade++;
+               return index;
+            };
+            ManyToOneBoundedChannel.MessageHandler handler = (msgTypeId, buffer, index, length) -> {
+               if (buffer.getInt(index) != sentinelValue) {
+                  throw new RuntimeException("CANNOT HAPPEN!");
+               }
+               if (DELAY_CONSUMER != 0) {
+                  Blackhole.consumeCPU(DELAY_CONSUMER);
+               }
+            };
+            receiveOperation = counters -> {
+               final int done = jgroupsChannel.read(handler);
+               if (done == 0) {
+                  counters.pollsFailed++;
+                  backoff();
+               } else {
+                  counters.pollsMade += done;
+               }
+               return done;
+            };
+            isEmpty = () -> jgroupsChannel.size() == 0;
+            break;
+         default:
+            throw new UnsupportedOperationException("unsupported ring buffer type");
+      }
+   }
+
+   @AuxCounters
+   @State(Scope.Thread)
+   public static class PollCounters {
+
+      public long pollsFailed;
+      public long pollsMade;
+   }
+
+   @AuxCounters
+   @State(Scope.Thread)
+   public static class OfferCounters {
+
+      public long offersFailed;
+      public long offersMade;
+   }
+
+   @Benchmark
+   @Group
+   public int send(OfferCounters counters) {
+      final int index = sendOperation.applyAsInt(counters);
+      if (DELAY_PRODUCER != 0) {
+         Blackhole.consumeCPU(DELAY_PRODUCER);
+      }
+      return index;
+   }
+
+   @Benchmark
+   @Group
+   public int receive(PollCounters counters) {
+      return receiveOperation.applyAsInt(counters);
+   }
+
+   @TearDown(Level.Iteration)
+   public void emptyRingBuffer() {
+      synchronized (receiveOperation) {
+         PollCounters dummy = new PollCounters();
+         while (!isEmpty.getAsBoolean()) {
+            while (receiveOperation.applyAsInt(dummy) == 0) {
+               backoff();
+            }
+         }
+      }
+   }
+
+   protected void backoff() {
+      Thread.onSpinWait();
+   }
+}


### PR DESCRIPTION
And finally got some hints of weird behaviours:

```
Benchmark                                    (bytes)  (capacity)  (ringBufferType)   Mode  Cnt   Score    Error   Units
ManyToOneStreamBenchmark.group:offersFailed     1000      132000            agrona  thrpt   20   5.273 ±  1.125  ops/us
ManyToOneStreamBenchmark.group:offersMade       1000      132000            agrona  thrpt   20  10.063 ±  0.283  ops/us
ManyToOneStreamBenchmark.group:pollsFailed      1000      132000            agrona  thrpt   20   0.001 ±  0.001  ops/us
ManyToOneStreamBenchmark.group:pollsMade        1000      132000            agrona  thrpt   20  10.003 ±  0.278  ops/us
ManyToOneStreamBenchmark.group:offersFailed     1000      132000           jgroups  thrpt   20   8.765 ±  0.405  ops/us
ManyToOneStreamBenchmark.group:offersMade       1000      132000           jgroups  thrpt   20  10.096 ±  0.257  ops/us
ManyToOneStreamBenchmark.group:pollsFailed      1000      132000           jgroups  thrpt   20   0.003 ±  0.010  ops/us
ManyToOneStreamBenchmark.group:pollsMade        1000      132000           jgroups  thrpt   20  10.069 ±  0.242  ops/us
```

The numbers shows that jgroups channels are faster to offer: they're limited by the consumer speed, but they're able to fill the available buffer faster, failing to find available space more times (5.273 agrona vs 8.765 jgroups offersFailed)